### PR TITLE
Fixing a bug of mixing data stored on gpu and a model stored on cpu w…

### DIFF
--- a/main.py
+++ b/main.py
@@ -299,7 +299,8 @@ def main():
         optimizer.load_state_dict(checkpoint['optimizer'])
         print("=> checkpoint state loaded.")
 
-    model = torch.nn.DataParallel(model)
+    if cuda:
+        model = torch.nn.DataParallel(model)
 
     # Data loading code
     print("=> creating data loaders ... ")


### PR DESCRIPTION
my PR fixes the following bug:
`RuntimeError: expected device cuda:0 but got device cpu`

... while running this command:
`python main.py --cpu --evaluate [path2checkpoint]`